### PR TITLE
fix references to samweb.fnal.gov

### DIFF
--- a/libexec/fife_wrap
+++ b/libexec/fife_wrap
@@ -1478,9 +1478,12 @@ exit
                 extra = {"encoding": "utf-8", "errors": "replace"}
             else:
                 extra = {}
+            url = "https://sam%s.fnal.gov:8483/sam/%s/api/values/data_disks" % (
+                 self.experiment,self.experiment
+            )
+            url = url.replace("samsamdev","samdev")
             l = subprocess.Popen(
-                "wget -O - 'http://samweb.fnal.gov:8480/sam/%s/api/values/data_disks'"
-                % self.experiment,
+                "wget -O - '%s'" % url,
                 shell = True,
                 stdout=subprocess.PIPE,
                 stderr=nowhere,
@@ -1611,14 +1614,7 @@ exit
         if self.options.dry_run:
             print('ifdh addFileLocation "%s" "%s"' % (of, loc))
         else:
-            try: 
-                self.ih.addFileLocation(of, loc)
-            except: 
-                """older ifdhs don't have addFileLocation so fake it with wget since curl is having trouble with proxies..."""
-                os.system(
-                    "wget --no-check-certificate  --certificate=$X509_USER_PROXY --ca-certificate=$X509_USER_PROXY --ca-directory=/etc/grid-security/certificates --private-key=$X509_USER_PROXY --post-data 'add=%s' 'https://samweb.fnal.gov:8483/sam/%s/api/files/name/%s/locations'"
-                    % (loc, self.experiment, of)
-                )
+            self.ih.addFileLocation(of, loc)
 
     def pre_file_loop(self):
         self.find_ifdhc()

--- a/test/t2.bash
+++ b/test/t2.bash
@@ -19,7 +19,7 @@ setup_tests() {
    export SAM_EXPERIMENT=samdev
    #export SAM_STATION=samdev-test
    export SAM_STATION=samdev
-   export IFDH_BASE_URI="http://samweb.fnal.gov:8480/sam/samdev/api"
+   export IFDH_BASE_URI="https://samdev.fnal.gov:8483/sam/samdev/api"
    export IFDH_CP_MAXRETRIES=0
 
    # pick an experiment pnfs area from whats available


### PR DESCRIPTION
Central samweb.fnal.gov is no more, there are now per-instance containers with their own hostnames....