### PR TITLE
Misc fixes: setups,  expunge X509_USER_PROXY , fix IFDH_BASE_URI, detatch poms_client

### DIFF
--- a/bin/fake_jobsub
+++ b/bin/fake_jobsub
@@ -11,7 +11,6 @@
 export using_dag=false
 
 scan_arguments() {
-   next_is_proxy=false
    next_is_group=false
    for i in "$@"
    do
@@ -138,7 +137,7 @@ fake_condor_submit() {
 
        cp $workdir/$basecmd $jobdir/$basecmd
 
-       fakegli=" HOME=$workdir/home X509_USER_PROXY='$proxy' TMPDIR='$jobdir' _CONDOR_SCRATCH_DIR='$jobdir' CONDOR_EXEC='$CONDOR_EXEC' OSG_SQUID_LOCATION='squid.fnal.gov:3128' X509_USER_CERT='$proxy' "
+       fakegli=" HOME=$workdir/home TMPDIR='$jobdir' _CONDOR_SCRATCH_DIR='$jobdir' CONDOR_EXEC='$CONDOR_EXEC' OSG_SQUID_LOCATION='squid.fnal.gov:3128' "
        
        use_environment=`echo "$environment" | sed -e "s/\\\$(Cluster)/$cluster/g" -e "s/\\\$(Process)/$i/g" -e "s/=/='/g" -e s"/;/'  /g" -e "s/$/'/"`
        use_output=`echo "$output" | sed -e "s/\\\$(Cluster)/$cluster/" -e "s/\\\$(Process)/$i/"`

--- a/bin/fife_launch
+++ b/bin/fife_launch
@@ -36,11 +36,6 @@ try:
 except:
   pass
 
-try:
-    import poms_client
-except:
-    pass
-
 
 def check_exp_err(k, v1, v):
     if v1 and not v:
@@ -377,9 +372,18 @@ class launcher(object):
             print("Initialize dd/mc client | Logging in as: %s " % username)
             
             # Login to the MC/DD clients, verify the credentials are valid
+            token_file = os.environ.get("BEARER_TOKEN_FILE", False)
+            if not token_file:
+                uid = os.environ.get("ID", str(os.geteuid()))
+                token_dir = os.environ.get("XDG_RUNTIME_DIR", "/tmp")
+                token_file = token_dir + "/" + "bt_u" + uid
+
+            with open(token_file, "r") as tf:
+                token = tf.read().strip()
+
             creds = {
-                "metacat": self.mc_client.login_x509(username, os.environ['X509_USER_PROXY']),
-                "data_dispatcher": self.dd_client.login_x509(username, os.environ['X509_USER_PROXY'])
+                "metacat": self.mc_client.login_token(username, token),
+                "data_dispatcher": self.dd_client.login_token(username, token)
             }
             for service, vals in creds.items():
                 if not vals or len(vals) != 2:
@@ -646,23 +650,6 @@ class launcher(object):
                     if "  -e %s \\" % k  not in res:
                         res.append("  -e %s \\" % k)
 
-            if self.cfg.has_section("poms_campaign_layer"):
-                #
-                # do the full poms_client game:
-                # -- register the campaign
-                # -- request a task_id
-                #
-                campaign_kwargs = {}
-                for k, v1 in self.cfg_items("poms_campaign_layer", raw=1):
-                    v = self.cfg_get("poms_campaign_layer", k, vars=self.cfg_globals)
-                    check_exp_err(k, v1, v)
-                    campaign_kwargs[k] = v
-
-                campaign_id = poms_client.register_poms_campaign(**campaign_kwargs)
-                poms_get_id_kwargs = {"campaign": campaign_id}
-            else:
-                poms_get_id_kwargs = {}
-
             for k, v1 in self.cfg_items("submit", raw=1):
                 if k == "n_files_per_job":
                     continue
@@ -839,44 +826,6 @@ class launcher(object):
                     check_exp_err(k, v1, v)
                     if k.startswith("arg_"):
                         res.append("      %s \\" % v)
-
-            if self.cfg.has_section("poms_get_task_id"):
-
-                if os.environ.get("POMS_TEST", "") != "":
-                    poms_get_id_kwargs["test"] = os.environ["POMS_TEST"]
-
-                if os.environ.get("POMS_PARENT_TASK_ID", "") != "":
-                    poms_get_id_kwargs["parent_task_id"] = os.environ[
-                        "POMS_PARENT_TASK_ID"
-                    ]
-                poms_get_id_kwargs["command_executed"] = "\n".join(res)
-
-                for k, v1 in self.cfg_items("poms_get_task_id", raw=1):
-                    v = self.cfg_get("poms_get_task_id", k, vars=self.cfg_globals)
-                    check_exp_err(k, v1, v)
-                    poms_get_id_kwargs[k] = v
-
-                #
-                # looks redundant, allows override from config file
-                # or value from register_poms_campaign
-                #
-                campaign_id = poms_get_id_kwargs["campaign"]
-
-                task_id = poms_client.get_task_id_for(**poms_get_id_kwargs)
-
-                n = res.index("jobsub_submit \\") + 1
-
-                res.insert(n, " -e POMS_CAMPAIGN_ID=%s \\" % campaign_id)
-                res.insert(n, " -e POMS_TASK_ID=%s \\" % task_id)
-                res.insert(
-                    n,
-                    """ -l "+FIFE_CATEGORIES='\\"POMS_TASK_ID_%s,POMS_CAMPAIGN_ID_%s,%s\\"'"  \\"""
-                    % (task_id, campaign_id, os.environ.get("POMS_CAMPAIGN_TAGS", "")),
-                )
-                res.insert(n, ' -l "+POMS_TASK_ID=%s"  \\' % task_id)
-                res.insert(n, ' -l "+POMS_CAMPAIGN_ID=%s"  \\' % campaign_id)
-
-            res.append("")
 
         elif self.cfg.has_section("submit_dag"):
             # XXX not doing dags -- yet

--- a/bin/ifdh_batch_copy
+++ b/bin/ifdh_batch_copy
@@ -458,7 +458,7 @@ if __name__ == "__main__":
         os.environ["EXPERIMENT"] = o.experiment
         os.environ["SAM_EXPERIMENT"] = o.experiment
         os.environ["IFDH_BASE_URI"] = (
-            "http://sam%s.fnal.gov:8480/sam/%s/api" % 
+            "https://sam%s.fnal.gov:8483/sam/%s/api" % 
                (o.experiment, o.experiment)
         ).replace("samsamdev","samdev")
 

--- a/bin/metacat_audit_dataset
+++ b/bin/metacat_audit_dataset
@@ -141,7 +141,7 @@ if __name__ == "__main__":
         os.environ["EXPERIMENT"] = o.experiment
         os.environ["SAM_EXPERIMENT"] = o.experiment
         os.environ["IFDH_BASE_URI"] = (
-            "http://sam%s.fnal.gov:8480/sam/%s/api" % 
+            "https://sam%s.fnal.gov:8483/sam/%s/api" % 
                (o.experiment, o.experiment)
         ).replace("samsamdev","samdev")
     else:
@@ -149,9 +149,6 @@ if __name__ == "__main__":
             "Error: Need either --experiment or $EXPERIMENT $SAM_EXPERIMENT in environment"
         )
         sys.exit(1)
-
-    cert = get_standard_certificate_path(o)
-    os.environ["X509_USER_PROXY"] = cert
 
     if not o.name:
         parser.error("expected --name dataset-name or --did dataset-did")

--- a/bin/metacat_dataset_duplicate_kids
+++ b/bin/metacat_dataset_duplicate_kids
@@ -181,7 +181,7 @@ if __name__ == "__main__":
         os.environ["EXPERIMENT"] = o.experiment
         os.environ["SAM_EXPERIMENT"] = o.experiment
         os.environ["IFDH_BASE_URI"] = (
-            "http://sam%s.fnal.gov:8480/sam/%s/api" % 
+            "https://sam%s.fnal.gov:8483/sam/%s/api" % 
                (o.experiment, o.experiment)
         ).replace("samsamdev","samdev")
     else:
@@ -189,9 +189,6 @@ if __name__ == "__main__":
             "Error: Need either --experiment or $EXPERIMENT $SAM_EXPERIMENT in environment"
         )
         sys.exit(1)
-
-    cert = get_standard_certificate_path(o)
-    os.environ["X509_USER_PROXY"] = cert
 
     if not o.dims:
         parser.error("expected --dims dimensions")

--- a/bin/metacat_dataset_stage_status
+++ b/bin/metacat_dataset_stage_status
@@ -113,7 +113,7 @@ if __name__ == "__main__":
         os.environ["EXPERIMENT"] = o.experiment
         os.environ["SAM_EXPERIMENT"] = o.experiment
         os.environ["IFDH_BASE_URI"] = (
-            "http://sam%s.fnal.gov:8480/sam/%s/api" % 
+            "https://sam%s.fnal.gov:8483/sam/%s/api" % 
                (o.experiment, o.experiment)
         ).replace("samsamdev","samdev")
     else:
@@ -121,9 +121,6 @@ if __name__ == "__main__":
             "Error: Need either --experiment or $EXPERIMENT $SAM_EXPERIMENT in environment"
         )
         sys.exit(1)
-
-    cert = get_standard_certificate_path(o)
-    os.environ["X509_USER_PROXY"] = cert
 
     if not o.name and not o.file:
         parser.error("expected --name dataset-name or --file filename")

--- a/bin/metacat_validate_dataset
+++ b/bin/metacat_validate_dataset
@@ -113,7 +113,7 @@ if __name__ == "__main__":
         os.environ["EXPERIMENT"] = o.experiment
         os.environ["SAM_EXPERIMENT"] = o.experiment
         os.environ["IFDH_BASE_URI"] = (
-            "http://sam%s.fnal.gov:8480/sam/%s/api" % 
+            "https://sam%s.fnal.gov:8483/sam/%s/api" % 
                (o.experiment, o.experiment)
         ).replace("samsamdev","samdev")
     else:
@@ -121,9 +121,6 @@ if __name__ == "__main__":
             "Error: Need either --experiment or $EXPERIMENT $SAM_EXPERIMENT in environment"
         )
         sys.exit(1)
-
-    cert = get_standard_certificate_path(o)
-    os.environ["X509_USER_PROXY"] = cert
 
     if not o.name and not o.file:
         parser.error("expected --name dataset-name or --file filename")

--- a/bin/sam_add_dataset
+++ b/bin/sam_add_dataset
@@ -542,11 +542,6 @@ def main():
         help="execute a child program in a new process to extract metadata only sam_metadata_dumper currently supported",
     )
     p.add_option(
-        "-c",
-        "--cert",
-        help="x509 certificate for authentication. If not specified, use $X509_USER_PROXY, $X509_USER_CERT/$X509_USER_KEY or standard grid proxy location",
-    )
-    p.add_option(
         "--no-rename",
         action="store_true",
         default=False,
@@ -586,7 +581,7 @@ def main():
         os.environ["EXPERIMENT"] = o.experiment
         os.environ["SAM_EXPERIMENT"] = o.experiment
         os.environ["IFDH_BASE_URI"] = (
-            "http://sam%s.fnal.gov:8480/sam/%s/api" % 
+            "https://sam%s.fnal.gov:8483/sam/%s/api" % 
                (o.experiment, o.experiment)
         ).replace("samsamdev","samdev")
         experiment = o.experiment
@@ -599,10 +594,8 @@ def main():
     if o.user:
         user = o.user
 
-    cert = get_standard_certificate_path(o)
-    os.environ["X509_USER_PROXY"] = cert
 
-    samweb = samweb_client.SAMWebClient(experiment=experiment, cert=cert)
+    samweb = samweb_client.SAMWebClient(experiment=experiment)
 
     jsonFile = o.metadata
 

--- a/bin/sam_archive_dataset
+++ b/bin/sam_archive_dataset
@@ -221,7 +221,7 @@ if __name__ == "__main__":
         os.environ["EXPERIMENT"] = o.experiment
         os.environ["SAM_EXPERIMENT"] = o.experiment
         os.environ["IFDH_BASE_URI"] = (
-            "http://sam%s.fnal.gov:8480/sam/%s/api" % 
+            "https://sam%s.fnal.gov:8483/sam/%s/api" % 
                (o.experiment, o.experiment)
         ).replace("samsamdev","samdev")
     else:
@@ -230,8 +230,6 @@ if __name__ == "__main__":
         )
         sys.exit(1)
 
-    cert = get_standard_certificate_path(o)
-    os.environ["X509_USER_PROXY"] = cert
 
     if o.experiment == "samdev":
         edir = "fermilab"

--- a/bin/sam_archive_directory_image
+++ b/bin/sam_archive_directory_image
@@ -129,7 +129,7 @@ if __name__ == "__main__":
         os.environ["EXPERIMENT"] = o.experiment
         os.environ["SAM_EXPERIMENT"] = o.experiment
         os.environ["IFDH_BASE_URI"] = (
-            "http://sam%s.fnal.gov:8480/sam/%s/api" % 
+            "https://sam%s.fnal.gov:8483/sam/%s/api" % 
                (o.experiment, o.experiment)
         ).replace("samsamdev","samdev")
     else:
@@ -145,9 +145,6 @@ if __name__ == "__main__":
             "Error: need a --src= directory whose contents are to be archived!"
         )
         sys.exit(1)
-
-    cert = get_standard_certificate_path(o)
-    os.environ["X509_USER_PROXY"] = cert
 
     samweb = samweb_client.SAMWebClient(experiment=o.experiment)
 

--- a/bin/sam_audit_dataset
+++ b/bin/sam_audit_dataset
@@ -141,7 +141,7 @@ if __name__ == "__main__":
         os.environ["EXPERIMENT"] = o.experiment
         os.environ["SAM_EXPERIMENT"] = o.experiment
         os.environ["IFDH_BASE_URI"] = (
-            "http://sam%s.fnal.gov:8480/sam/%s/api" % 
+            "https://sam%s.fnal.gov:8483/sam/%s/api" % 
                (o.experiment, o.experiment)
         ).replace("samsamdev","samdev")
     else:
@@ -149,9 +149,6 @@ if __name__ == "__main__":
             "Error: Need either --experiment or $EXPERIMENT $SAM_EXPERIMENT in environment"
         )
         sys.exit(1)
-
-    cert = get_standard_certificate_path(o)
-    os.environ["X509_USER_PROXY"] = cert
 
     if not o.name:
         parser.error("expected --name dataset-name or --did dataset-did")

--- a/bin/sam_clone_dataset
+++ b/bin/sam_clone_dataset
@@ -220,7 +220,7 @@ if __name__ == "__main__":
         os.environ["EXPERIMENT"] = o.experiment
         os.environ["SAM_EXPERIMENT"] = o.experiment
         os.environ["IFDH_BASE_URI"] = (
-            "http://sam%s.fnal.gov:8480/sam/%s/api" % 
+            "https://sam%s.fnal.gov:8483/sam/%s/api" % 
                (o.experiment, o.experiment)
         ).replace("samsamdev","samdev")
     else:
@@ -228,9 +228,6 @@ if __name__ == "__main__":
             "Error: Need either --experiment or $EXPERIMENT $SAM_EXPERIMENT in environment"
         )
         sys.exit(1)
-
-    cert = get_standard_certificate_path(o)
-    os.environ["X509_USER_PROXY"] = cert
 
     if o.verbose > 1:
         logging.basicConfig(level=logging.DEBUG)

--- a/bin/sam_condense_dataset
+++ b/bin/sam_condense_dataset
@@ -189,7 +189,7 @@ if __name__ == "__main__":
         os.environ["EXPERIMENT"] = o.experiment
         os.environ["SAM_EXPERIMENT"] = o.experiment
         os.environ["IFDH_BASE_URI"] = (
-            "http://sam%s.fnal.gov:8480/sam/%s/api" % 
+            "https://sam%s.fnal.gov:8483/sam/%s/api" % 
                (o.experiment, o.experiment)
         ).replace("samsamdev","samdev")
 
@@ -198,9 +198,6 @@ if __name__ == "__main__":
             "Error: Need either --experiment or $EXPERIMENT $SAM_EXPERIMENT in environment"
         )
         sys.exit(1)
-
-    cert = get_standard_certificate_path(o)
-    os.environ["X509_USER_PROXY"] = cert
 
     if not o.name:
         parser.error("expected --name dataset-name")

--- a/bin/sam_copy2scratch_dataset
+++ b/bin/sam_copy2scratch_dataset
@@ -222,7 +222,7 @@ if __name__ == "__main__":
         os.environ["EXPERIMENT"] = o.experiment
         os.environ["SAM_EXPERIMENT"] = o.experiment
         os.environ["IFDH_BASE_URI"] = (
-            "http://sam%s.fnal.gov:8480/sam/%s/api" % 
+            "https://sam%s.fnal.gov:8483/sam/%s/api" % 
                (o.experiment, o.experiment)
         ).replace("samsamdev","samdev")
     else:
@@ -230,9 +230,6 @@ if __name__ == "__main__":
             "Error: Need either --experiment or $EXPERIMENT $SAM_EXPERIMENT in environment"
         )
         sys.exit(1)
-
-    cert = get_standard_certificate_path(o)
-    os.environ["X509_USER_PROXY"] = cert
 
     if o.experiment == "samdev":
         edir = "fermilab"

--- a/bin/sam_dataset_duplicate_kids
+++ b/bin/sam_dataset_duplicate_kids
@@ -181,7 +181,7 @@ if __name__ == "__main__":
         os.environ["EXPERIMENT"] = o.experiment
         os.environ["SAM_EXPERIMENT"] = o.experiment
         os.environ["IFDH_BASE_URI"] = (
-            "http://sam%s.fnal.gov:8480/sam/%s/api" % 
+            "https://sam%s.fnal.gov:8483/sam/%s/api" % 
                (o.experiment, o.experiment)
         ).replace("samsamdev","samdev")
     else:
@@ -189,9 +189,6 @@ if __name__ == "__main__":
             "Error: Need either --experiment or $EXPERIMENT $SAM_EXPERIMENT in environment"
         )
         sys.exit(1)
-
-    cert = get_standard_certificate_path(o)
-    os.environ["X509_USER_PROXY"] = cert
 
     if not o.dims:
         parser.error("expected --dims dimensions")

--- a/bin/sam_dataset_stage_status
+++ b/bin/sam_dataset_stage_status
@@ -113,7 +113,7 @@ if __name__ == "__main__":
         os.environ["EXPERIMENT"] = o.experiment
         os.environ["SAM_EXPERIMENT"] = o.experiment
         os.environ["IFDH_BASE_URI"] = (
-            "http://sam%s.fnal.gov:8480/sam/%s/api" % 
+            "https://sam%s.fnal.gov:8483/sam/%s/api" % 
                (o.experiment, o.experiment)
         ).replace("samsamdev","samdev")
     else:
@@ -121,9 +121,6 @@ if __name__ == "__main__":
             "Error: Need either --experiment or $EXPERIMENT $SAM_EXPERIMENT in environment"
         )
         sys.exit(1)
-
-    cert = get_standard_certificate_path(o)
-    os.environ["X509_USER_PROXY"] = cert
 
     if not o.name and not o.file:
         parser.error("expected --name dataset-name or --file filename")

--- a/bin/sam_extract_dataset_metadata
+++ b/bin/sam_extract_dataset_metadata
@@ -98,7 +98,7 @@ if __name__ == "__main__":
         os.environ["EXPERIMENT"] = o.experiment
         os.environ["SAM_EXPERIMENT"] = o.experiment
         os.environ["IFDH_BASE_URI"] = (
-            "http://sam%s.fnal.gov:8480/sam/%s/api" % 
+            "https://sam%s.fnal.gov:8483/sam/%s/api" % 
                (o.experiment, o.experiment)
         ).replace("samsamdev","samdev")
     else:
@@ -106,9 +106,6 @@ if __name__ == "__main__":
             "Error: Need either --experiment or $EXPERIMENT $SAM_EXPERIMENT in environment"
         )
         sys.exit(1)
-
-    cert = get_standard_certificate_path(o)
-    os.environ["X509_USER_PROXY"] = cert
 
     if not o.name:
         parser.error("expected --name dataset-name")

--- a/bin/sam_modify_dataset_metadata
+++ b/bin/sam_modify_dataset_metadata
@@ -68,7 +68,7 @@ if __name__ == "__main__":
         os.environ["EXPERIMENT"] = o.experiment
         os.environ["SAM_EXPERIMENT"] = o.experiment
         os.environ["IFDH_BASE_URI"] = (
-            "http://sam%s.fnal.gov:8480/sam/%s/api" % 
+            "https://sam%s.fnal.gov:8483/sam/%s/api" % 
                (o.experiment, o.experiment)
         ).replace("samsamdev","samdev")
     else:
@@ -76,9 +76,6 @@ if __name__ == "__main__":
             "Error: Need either --experiment or $EXPERIMENT $SAM_EXPERIMENT in environment"
         )
         sys.exit(1)
-
-    cert = get_standard_certificate_path(o)
-    os.environ["X509_USER_PROXY"] = cert
 
     if not o.name:
         parser.error("expected --name dataset-name")

--- a/bin/sam_project_caffeine
+++ b/bin/sam_project_caffeine
@@ -128,7 +128,7 @@ if __name__ == "__main__":
         os.environ["EXPERIMENT"] = o.experiment
         os.environ["SAM_EXPERIMENT"] = o.experiment
         os.environ["IFDH_BASE_URI"] = (
-            "http://sam%s.fnal.gov:8480/sam/%s/api" % 
+            "https://sam%s.fnal.gov:8483/sam/%s/api" % 
                (o.experiment, o.experiment)
         ).replace("samsamdev","samdev")
     else:

--- a/bin/sam_remove_location_dataset
+++ b/bin/sam_remove_location_dataset
@@ -60,7 +60,7 @@ if __name__ == "__main__":
         os.environ["EXPERIMENT"] = o.experiment
         os.environ["SAM_EXPERIMENT"] = o.experiment
         os.environ["IFDH_BASE_URI"] = (
-            "http://sam%s.fnal.gov:8480/sam/%s/api" % 
+            "https://sam%s.fnal.gov:8483/sam/%s/api" % 
                (o.experiment, o.experiment)
         ).replace("samsamdev","samdev")
     else:
@@ -68,9 +68,6 @@ if __name__ == "__main__":
             "Error: Need either --experiment or $EXPERIMENT $SAM_EXPERIMENT in environment"
         )
         sys.exit(1)
-
-    cert = get_standard_certificate_path(o)
-    os.environ["X509_USER_PROXY"] = cert
 
     if not o.name:
         parser.error("expected --name dataset-name")

--- a/bin/sam_restore_directory_image
+++ b/bin/sam_restore_directory_image
@@ -155,7 +155,7 @@ if __name__ == "__main__":
         os.environ["EXPERIMENT"] = o.experiment
         os.environ["SAM_EXPERIMENT"] = o.experiment
         os.environ["IFDH_BASE_URI"] = (
-            "http://sam%s.fnal.gov:8480/sam/%s/api" % 
+            "https://sam%s.fnal.gov:8483/sam/%s/api" % 
                (o.experiment, o.experiment)
         ).replace("samsamdev","samdev")
     else:
@@ -163,9 +163,6 @@ if __name__ == "__main__":
             "Error: Need either --experiment or $EXPERIMENT $SAM_EXPERIMENT in environment"
         )
         sys.exit(1)
-
-    cert = get_standard_certificate_path(o)
-    os.environ["X509_USER_PROXY"] = cert
 
     samweb = samweb_client.SAMWebClient(experiment=o.experiment)
 

--- a/bin/sam_retire_dataset
+++ b/bin/sam_retire_dataset
@@ -127,7 +127,7 @@ if __name__ == "__main__":
         os.environ["EXPERIMENT"] = o.experiment
         os.environ["SAM_EXPERIMENT"] = o.experiment
         os.environ["IFDH_BASE_URI"] = (
-            "http://sam%s.fnal.gov:8480/sam/%s/api" % 
+            "https://sam%s.fnal.gov:8483/sam/%s/api" % 
                (o.experiment, o.experiment)
         ).replace("samsamdev","samdev")
     else:
@@ -135,9 +135,6 @@ if __name__ == "__main__":
             "Error: Need either --experiment or $EXPERIMENT $SAM_EXPERIMENT in environment"
         )
         sys.exit(1)
-
-    cert = get_standard_certificate_path(o)
-    os.environ["X509_USER_PROXY"] = cert
 
     if not o.name:
         parser.error("expected --name dataset-name")

--- a/bin/sam_unclone_dataset
+++ b/bin/sam_unclone_dataset
@@ -60,7 +60,7 @@ if __name__ == "__main__":
         os.environ["EXPERIMENT"] = o.experiment
         os.environ["SAM_EXPERIMENT"] = o.experiment
         os.environ["IFDH_BASE_URI"] = (
-            "http://sam%s.fnal.gov:8480/sam/%s/api" % 
+            "https://sam%s.fnal.gov:8483/sam/%s/api" % 
                (o.experiment, o.experiment)
         ).replace("samsamdev","samdev")
     else:
@@ -68,9 +68,6 @@ if __name__ == "__main__":
             "Error: Need either --experiment or $EXPERIMENT $SAM_EXPERIMENT in environment"
         )
         sys.exit(1)
-
-    cert = get_standard_certificate_path(o)
-    os.environ["X509_USER_PROXY"] = cert
 
     if not o.name:
         parser.error("expected --name dataset-name")

--- a/bin/sam_validate_dataset
+++ b/bin/sam_validate_dataset
@@ -113,7 +113,7 @@ if __name__ == "__main__":
         os.environ["EXPERIMENT"] = o.experiment
         os.environ["SAM_EXPERIMENT"] = o.experiment
         os.environ["IFDH_BASE_URI"] = (
-            "http://sam%s.fnal.gov:8480/sam/%s/api" % 
+            "https://sam%s.fnal.gov:8483/sam/%s/api" % 
                (o.experiment, o.experiment)
         ).replace("samsamdev","samdev")
     else:
@@ -121,9 +121,6 @@ if __name__ == "__main__":
             "Error: Need either --experiment or $EXPERIMENT $SAM_EXPERIMENT in environment"
         )
         sys.exit(1)
-
-    cert = get_standard_certificate_path(o)
-    os.environ["X509_USER_PROXY"] = cert
 
     if not o.name and not o.file:
         parser.error("expected --name dataset-name or --file filename")

--- a/lib/fife_sam_utils.py
+++ b/lib/fife_sam_utils.py
@@ -123,30 +123,6 @@ def do_getawscreds(debug = False):
     f.close()
     os.unlink(fname)
 
-def get_standard_certificate_path(options):
-  logging.debug('looking for cert')
-
-  if hasattr(options,'cert') and options.cert:
-    cert = options.cert
-  else:
-    cert = os.environ.get('X509_USER_PROXY',None)
-    if not cert:
-      cert = os.environ.get('X509_USER_CERT',None)
-      key = os.environ.get('X509_USER_KEY',None)
-      if cert and key: cert = (cert, key)
-    if not cert:
-      logging.debug('trying to create cert for you as none were found')
-      logging.debug('looking for cert with ifdh')
-      ih = ifdh.ifdh()
-      cert = ih.getProxy()
-      logging.debug('ifdh returns %s' % cert)
-
-  if not cert:
-    sys.exit("unable to find cert and unable to make one")
-
-  logging.debug('cert is %s' % cert)
-  return cert
-
 class fake_project_dataset:
 
     def __init__( self, name ):
@@ -1110,7 +1086,11 @@ def clone( d, dest, subdirf = twodeep, just_say=False, batch_size = 1, verbose =
     if connect_project:
         purl = d.findProject(projname, os.environ.get('SAM_STATION',experiment))
     else:
-        purl = d.startProject(projname, os.environ.get('SAM_STATION',experiment), d.name, user, experiment)
+        try:
+            purl = d.startProject(projname, os.environ.get('SAM_STATION',experiment), d.name, user, experiment)
+        except:
+            logging.exception()
+
         if not purl:
             logging.error("startProject failed.")
             sys.exit(1)

--- a/lib/migrator.py
+++ b/lib/migrator.py
@@ -50,7 +50,6 @@ class Migrator:
         with open(tfn, "r") as tf:
             tok = tf.read().strip()
         self.metacat.login_token(os.environ.get("USER"), tok)
-        pf = self.ih.getProxy()
         self.last_reauth = time.time()
 
     def samgetmultiplemetadata(self, flist: List[str]) -> List[Dict[str, Any]]:

--- a/libexec/fife_wrap
+++ b/libexec/fife_wrap
@@ -853,52 +853,6 @@ class Wrapper:
             )
             scriptlist.append("echo; ups active; echo; echo")
 
-        #
-        # Now emergency fail-back... Hopefully the setup stuff above
-        # got us some sort of package management with ifdhc, but just
-        # in case...
-        #
-        # if we have neither Spack nor UPS, setup fermilab/common Spack...
-        scriptlist.append('if [ -n "$SPACK_ROOT" -a -n "$PRODUCTS" ]; then')
-        scriptlist.append('. /cvmfs/fermilab.opensciencegrid.org/packages/common/setup-env.sh')
-        scriptlist.append("fi")
-        # If we have spack, but not ifdh, get that...
-        scriptlist.append('if [ -n "$SPACK_ROOT" -a -r "$SPACK_ROOT" ]; then')
-        scriptlist.append('   if [ -z "$IFDHC_CONFIG_DIR" ]; then')
-        #                        # we have Spack but no ifdhc...
-        scriptlist.append("      oss=$(spack arch --operating-system)")
-        scriptlist.append('      ienv="ifdh_env_${oss}_${IFDH_VERSION:-current}"')
-        scriptlist.append("      curhash=$(spack -e $ienv find --format '{hash}' ifdhc)")
-        scriptlist.append("      spack load ifdhc/$curhash")
-        scriptlist.append("   fi")
-
-        if self.options.data_dispatcher:
-            # if we're doing data_dispatcher, and it isn't set up, find that , too
-            scriptlist.append("   if echo $PYTHONPATH | grep -q data-dispatcher; then")
-            scriptlist.append("      :")
-            scriptlist.append("   else")
-            scriptlist.append("      lhash=$(spack find  --format '{hash}' data-dispatcher os=default_os | tail -1)")
-            scriptlist.append("      spack load /$lhash")
-            scriptlist.append("   fi")
-     
-        scriptlist.append("else")
-        # ... Otherwise we try to get UPS...
-        scriptlist.append(
-            '[ -z "$PRODUCTS" -a -r /cvmfs/fermilab.opensciencegrid.org/products/common/etc/setups.sh ] && source /cvmfs/fermilab.opensciencegrid.org/products/common/etc/setups.sh'
-        )
-        # this is mainly for corner case systems that have /grid/fermiapp
-        # mounted but not cvmfs.  Not sure if there are any left...
-        scriptlist.append(
-            '[ -z "$PRODUCTS" -a -r /grid/fermiapp/products/common/etc/setups.sh ] && source /grid/fermiapp/products/common/etc/setups.sh'
-        )
-        scriptlist.append('[ -z "$IFDHC_CONFIG_DIR" ] && source `UPS_OVERRIDE= ups setup ifdhc $IFDH_VERSION`')
-        if self.options.data_dispatcher:
-            scriptlist.append("   if echo $PYTHONPATH | grep -q data-dispatcher; then")
-            scriptlist.append("      :")
-            scriptlist.append("   else")
-            scriptlist.append("      UPS_OVERRIDE="" setup data_dispatcher")
-            scriptlist.append("   fi")
-        scriptlist.append("fi")
         if self.options.dry_run:
             print("# setup commands:")
         self.run_extracting_environment(scriptlist)

--- a/libexec/fife_wrap
+++ b/libexec/fife_wrap
@@ -857,13 +857,37 @@ class Wrapper:
                 % (d, d)
             )
             scriptlist.append("echo; ups active; echo; echo")
+
+        #
+        # Now emergency fail-back... Hopefully the setup stuff above
+        # got us some sort of package management with ifdhc, but just
+        # in case...
+        #
+        # if we have neither Spack nor UPS, setup fermilab/common Spack...
+        scriptlist.append('if [ -n "$SPACK_ROOT" -a -n "$PRODUCTS" ]; then')
+        scriptlist.append('. /cvmfs/fermilab.opensciencegrid.org/packages/common/setup-env.sh')
+        scriptlist.append("fi")
+        # If we have spack, but not ifdh, get that...
+        scriptlist.append('if [ -n "$SPACK_ROOT" -a -r "$SPACK_ROOT" ]; then')
+        scriptlist.append('   if [ -z "$IFDHC_CONFIG_DIR" ]; then')
+        #                        # we have Spack but no ifdhc...
+        scriptlist.append("      oss=$(spack arch --operating-system)")
+        scriptlist.append('      ienv="ifdh_env_${oss}_${IFDH_VERSION:-current}"')
+        scriptlist.append("      curhash=$(spack -e $ienv find --format '{hash}' ifdhc)")
+        scriptlist.append("      spack load ifdhc/$curhash")
+        scriptlist.append("   fi")
+        scriptlist.append("else")
+        # ... Otherwise we try to get UPS...
         scriptlist.append(
             '[ -z "$PRODUCTS" -a -r /cvmfs/fermilab.opensciencegrid.org/products/common/etc/setups.sh ] && source /cvmfs/fermilab.opensciencegrid.org/products/common/etc/setups.sh'
         )
+        # this is mainly for corner case systems that have /grid/fermiapp
+        # mounted but not cvmfs.  Not sure if there are any left...
         scriptlist.append(
             '[ -z "$PRODUCTS" -a -r /grid/fermiapp/products/common/etc/setups.sh ] && source /grid/fermiapp/products/common/etc/setups.sh'
         )
         scriptlist.append('[ -z "$IFDHC_CONFIG_DIR" ] && source `UPS_OVERRIDE= ups setup ifdhc $IFDH_VERSION`')
+        scriptlist.append("fi")
         if self.options.dry_run:
             print("# setup commands:")
         self.run_extracting_environment(scriptlist)

--- a/libexec/fife_wrap
+++ b/libexec/fife_wrap
@@ -823,8 +823,19 @@ class Wrapper:
                 scriptlist.append("source %s" % urllib_unquote(s))
         if self.options.setup:
             for s in self.options.setup:
+                pkg = s.strip()
+                if pkg.find(" ") > 0:
+                    pkg=pkg[:pkg.find(" ")]
+
+                scriptlist.append("unsetup %s 2>/dev/null || true" % pkg)
                 scriptlist.append("setup %s" % s)
         if self.options.setup_unquote:
+                pkg = urllib_unquote(s).strip()
+                if pkg.find(" ") > 0:
+                    pkg=pkg[:pkg.find(" ")]
+
+                scriptlist.append("unsetup %s 2>/dev/null || true" % pkg)
+                scriptlist.append("setup %s" % urllib_unquote(s))
             for s in self.options.setup_unquote:
                 scriptlist.append("setup %s" % urllib_unquote(s))
         if self.options.spack_load:

--- a/libexec/fife_wrap
+++ b/libexec/fife_wrap
@@ -830,13 +830,13 @@ class Wrapper:
                 scriptlist.append("unsetup %s 2>/dev/null || true" % pkg)
                 scriptlist.append("setup %s" % s)
         if self.options.setup_unquote:
+            for s in self.options.setup_unquote:
                 pkg = urllib_unquote(s).strip()
                 if pkg.find(" ") > 0:
                     pkg=pkg[:pkg.find(" ")]
 
                 scriptlist.append("unsetup %s 2>/dev/null || true" % pkg)
                 scriptlist.append("setup %s" % urllib_unquote(s))
-            for s in self.options.setup_unquote:
                 scriptlist.append("setup %s" % urllib_unquote(s))
         if self.options.spack_load:
             for s in self.options.spack_load:

--- a/libexec/fife_wrap
+++ b/libexec/fife_wrap
@@ -863,7 +863,7 @@ class Wrapper:
         scriptlist.append(
             '[ -z "$PRODUCTS" -a -r /grid/fermiapp/products/common/etc/setups.sh ] && source /grid/fermiapp/products/common/etc/setups.sh'
         )
-        scriptlist.append('[ -z "$IFDHC_DIR" ] && source `ups setup ifdhc`')
+        scriptlist.append('[ -z "$IFDHC_DIR" ] && source `UPS_OVERRIDE= ups setup ifdhc $IFDH_VERSION`')
         if self.options.dry_run:
             print("# setup commands:")
         self.run_extracting_environment(scriptlist)

--- a/libexec/fife_wrap
+++ b/libexec/fife_wrap
@@ -112,6 +112,7 @@ class DDInterface:
         self.dd_client.login_token(username, bt)
         self.mc_client.login_token(username, bt)
     else:
+        # we should probably drop this..
         self.dd_client.login_x509(username, os.environ['X509_USER_PROXY'])
         self.mc_client.login_x509(username, os.environ['X509_USER_PROXY'])
     

--- a/libexec/fife_wrap
+++ b/libexec/fife_wrap
@@ -1366,7 +1366,7 @@ exit
             # already did this..
             return
         pf = os.popen(
-            "for f in /cvmfs/fermilab.opensciencegrid.org/products/common/etc/setups /grid/fermiapp/products/common/etc/setups; do if [ -r $f ] ; then source $f; fi; done; source `ups setup ifdhc $IFDH_VERSION`; source `ups setup ifdhc_config $IFDH_VERSION`||true; echo $IFDHC_DIR/lib/python; echo $IFDHC_CONFIG_DIR"
+            "for f in /cvmfs/fermilab.opensciencegrid.org/products/common/etc/setups /grid/fermiapp/products/common/etc/setups; do if [ -r $f ] ; then source $f; fi; done; source `UPS_OVERRIDE= ups setup ifdhc $IFDH_VERSION`; source `UPS_OVERRIDE= ups setup ifdhc_config $IFDH_VERSION`||true; echo $IFDHC_DIR/lib/python; echo $IFDHC_CONFIG_DIR"
         )
         l = pf.readlines()
         if len(l):

--- a/libexec/fife_wrap
+++ b/libexec/fife_wrap
@@ -99,11 +99,6 @@ class DDInterface:
     self.dd_client = DataDispatcherClient()
     
   def Login(self, username):
-    # poms goes first
-    if os.environ.get("POMS_DATA_DISPATCHER_TASK_ID"):
-        self.dd_client.login_x509(username, os.environ['X509_USER_PROXY'])
-        self.mc_client.login_x509(username, os.environ['X509_USER_PROXY'])
-        return
     
     bt = ""
     btf = os.environ.get("BEARER_TOKEN_FILE", 
@@ -876,6 +871,16 @@ class Wrapper:
         scriptlist.append("      curhash=$(spack -e $ienv find --format '{hash}' ifdhc)")
         scriptlist.append("      spack load ifdhc/$curhash")
         scriptlist.append("   fi")
+
+        if self.options.data_dispatcher:
+            # if we're doing data_dispatcher, and it isn't set up, find that , too
+            scriptlist.append("   if echo $PYTHONPATH | grep -q data-dispatcher; then")
+            scriptlist.append("      :")
+            scriptlist.append("   else")
+            scriptlist.append("      lhash=$(spack find  --format '{hash}' data-dispatcher os=default_os | tail -1)")
+            scriptlist.append("      spack load /$lhash")
+            scriptlist.append("   fi")
+     
         scriptlist.append("else")
         # ... Otherwise we try to get UPS...
         scriptlist.append(
@@ -887,6 +892,12 @@ class Wrapper:
             '[ -z "$PRODUCTS" -a -r /grid/fermiapp/products/common/etc/setups.sh ] && source /grid/fermiapp/products/common/etc/setups.sh'
         )
         scriptlist.append('[ -z "$IFDHC_CONFIG_DIR" ] && source `UPS_OVERRIDE= ups setup ifdhc $IFDH_VERSION`')
+        if self.options.data_dispatcher:
+            scriptlist.append("   if echo $PYTHONPATH | grep -q data-dispatcher; then")
+            scriptlist.append("      :")
+            scriptlist.append("   else")
+            scriptlist.append("      UPS_OVERRIDE="" setup data_dispatcher")
+            scriptlist.append("   fi")
         scriptlist.append("fi")
         if self.options.dry_run:
             print("# setup commands:")

--- a/libexec/fife_wrap
+++ b/libexec/fife_wrap
@@ -863,7 +863,7 @@ class Wrapper:
         scriptlist.append(
             '[ -z "$PRODUCTS" -a -r /grid/fermiapp/products/common/etc/setups.sh ] && source /grid/fermiapp/products/common/etc/setups.sh'
         )
-        scriptlist.append('[ -z "$IFDHC_DIR" ] && source `UPS_OVERRIDE= ups setup ifdhc $IFDH_VERSION`')
+        scriptlist.append('[ -z "$IFDHC_CONFIG_DIR" ] && source `UPS_OVERRIDE= ups setup ifdhc $IFDH_VERSION`')
         if self.options.dry_run:
             print("# setup commands:")
         self.run_extracting_environment(scriptlist)

--- a/man/man1/sam_add_dataset.1
+++ b/man/man1/sam_add_dataset.1
@@ -54,9 +54,6 @@ json file of metadata you would like added to all files
 execute a child program \fISUBPROCESS\fN iin a new process to extract metadata
 -- only 'sam_metadata_dumper' currently supported
 .TP
-.B -c \fICERT\fB, --cert=\fICERT\fB
-x509 certificate for authentication. If not specified, use $X509_USER_PROXY, $X509_USER_CERT/$X509_USER_KEY or standard grid proxy location
-.TP
 .B -v|--verbose    
 turns on  verbose output
 

--- a/man/man1/sam_prestage_dataset.1
+++ b/man/man1/sam_prestage_dataset.1
@@ -29,11 +29,6 @@ use development server
 .B -s|--secure
 always use secure (SSL) mode
 .TP
-.B --cert=\fICERT\fB
-x509 certificate for authentication. If not specified,
-use $X509_USER_PROXY, $X509_USER_CERT/$X509_USER_KEY
-or standard grid proxy location
-.TP
 .B --key=\fIKEY\fB
 x509 key for authentication (defaults to same as
 certificate)

--- a/test/t1.bash
+++ b/test/t1.bash
@@ -11,8 +11,8 @@ esac
 prefix=$(dirname $prefix)
 
 # setup dependencies
-spack load ifdhc@2.7.2  os=fe
-spack load sam-web-client@3.6 os=fe
+spack load --first ifdhc@2.7.4  os=fe
+spack load --first sam-web-client@3.6 os=fe
 # add our path and pythnpath entries
 PATH=$prefix/bin:$PATH
 PYTHONPATH=$prefix/lib:$PYTHONPATH
@@ -52,7 +52,7 @@ setup_tests() {
    export SAM_EXPERIMENT=samdev
    #export SAM_STATION=samdev-test
    export SAM_STATION=samdev
-   export IFDH_BASE_URI="http://samdev.fnal.gov:8480/sam/samdev/api"
+   export IFDH_BASE_URI="https://samdev.fnal.gov:8483/sam/samdev/api"
    export IFDH_CP_MAXRETRIES=0
 
    exp=hypot
@@ -81,13 +81,8 @@ setup_tests() {
    ifdh ls $pnfs_dir || ifdh mkdir $pnfs_dir || true
    read dataset < dataset
    export dataset
-   export X509_USER_PROXY=/tmp/x509up_u`id -u`
-   rm -f $X509_USER_PROXY
-   kx509
-   voms-proxy-init -rfc -noregen -debug -voms fermilab:/fermilab/nova/Role=Analysis
    export IFDH_NO_PROXY=1
    # now in table file...
-   export X509_USER_PROXY=/tmp/x509up_u`id -u`
    export SSL_CERT_DIR=/etc/grid-security/certificates
    export CPN_DIR=/no/such/dir
    echo FIFE_UTILS_DIR=$FIFE_UTILS_DIR
@@ -337,7 +332,7 @@ test_validate_prune() {
 }
 
 test_validate_locality() {
-    sam_clone_dataset -v -b 2 --name $dataset --dest $pnfs_dir
+    sam_clone_dataset -e $EXPERIMENT -v -b 2 --name $dataset --dest $pnfs_dir
     sam_validate_dataset -v --name $dataset --locality > out
     sam_unclone_dataset -v -b 2 --name $dataset --dest $pnfs_dir
     grep Locality out
@@ -345,14 +340,14 @@ test_validate_locality() {
 
 test_clone() {
     count_report_files "before:" locs1
-    sam_clone_dataset -v -b 2 --name $dataset --dest $pnfs_dir
+    sam_clone_dataset -e $EXPERIMENT -v -b 2 --name $dataset --dest $pnfs_dir
     count_report_files "after:" locs2
     [ "$locs2" -gt "$locs1" ]
 }
 
 test_clone_n() {
     count_report_files "before:" locs1
-    sam_clone_dataset -v -N 3 -b 2 --name $dataset --dest $pnfs_dir
+    sam_clone_dataset -e $EXPERIMENT -v -N 3 -b 2 --name $dataset --dest $pnfs_dir
     count_report_files "after:" locs2
     [ "$locs2" -gt "$locs1" ]
 }

--- a/test/test_fife_wrap.sh
+++ b/test/test_fife_wrap.sh
@@ -11,14 +11,17 @@ prefix=$(dirname $prefix)
 . unittest.bash
 
 # setup dependencies
-spack load ifdhc@2.7.2  os=fe
-spack load sam-web-client@3.6 os=fe
+spack load --first ifdhc@2.7.4  os=default_os
+spack load --first sam-web-client@3.6 os=default_os
+export ifdh_load="2.7.4 os=default_os"
 # add our path and pythnpath entries
 export PATH=$prefix/bin:$PATH
 export PYTHONPATH=$prefix/lib:$PYTHONPATH
 export EXPERIMENT=samdev
-export X509_USER_PROXY=$(ifdh getProxy)
+# export X509_USER_PROXY=$(ifdh getProxy)
 export BEARER_TOKEN_FILE=$(ifdh getToken)
+
+printenv | grep TOKEN
 
 
 case "x$1" in
@@ -176,7 +179,6 @@ test_quot_env() {
     ../libexec/fife_wrap --debug --export-unquote FOO%3d%60bar%60_%60baz%60 --source /cvmfs/fermilab.opensciencegrid.org/packages/common/setup-env.sh --spack-load '--only dependencies fife-utils@3.7.3' --limit 4 --multifile --appname demo --appfamily demo --appvers v1_0  --exe cat --addoutput bar.root --rename unique --declare_metadata --add_location --add_to_dataset _poms_task --dataset_exclude '*.xyzzy' --dest $workdir --hash 2 -- '>bar.root' '<'  | tee tqe.out
 }
 
-export ifdh_load="2.7.2 os=fe"
 
 
 if [ ! -r /tmp/did_gen_cfg ]
@@ -189,8 +191,9 @@ printf "python: "
 which python
 ups active
 
+# dropped test_parallel_hashdir_lots , takes too long
 #testsuite fife_wrap_tests -s setup_proj -t end_proj test_quot_env
 
-testsuite fife_wrap_tests -s setup_proj -t end_proj test_parallel_hashdir_lots test_parallel test_pre_post_1 test_env_meta test_client_tmpl test_client_1 test_client_2 test_client_2a test_client_3 test_client_4 test_client_excl test_hash_dir test_hash_dir_sha test_quot_env test_multi_format_path test_ucondb_path
+testsuite fife_wrap_tests -s setup_proj -t end_proj test_pre_post_1 test_env_meta test_client_tmpl test_client_1 test_client_2 test_client_2a test_client_3 test_client_4 test_client_excl test_hash_dir test_hash_dir_sha test_quot_env test_multi_format_path test_ucondb_path test_parallel 
 
 fife_wrap_tests "$@"

--- a/test/unittest.bash
+++ b/test/unittest.bash
@@ -41,7 +41,8 @@ testsuite() {
                n_tests=\$(( n_tests + 1 ))
 	       if [ x\$verbose = "x-v" -o x\$verbose = "x-vv" ]
                then
-	           printf '%s \t...' \$_t
+                   
+	           printf \$(date -u -Iseconds)' %s \t...' \$_t
                fi
 	       \$${suitename}_test_setup > ${TMPDIR:-/tmp}/setup_out\$n_tests 2>&1
 	       if \$_t > ${TMPDIR:-/tmp}/test_case_out_\$\$ 2>&1

--- a/ups/fife_utils.table
+++ b/ups/fife_utils.table
@@ -35,7 +35,6 @@ Action=setup
     ExeActionRequired(setup_ifdhc_if_not_setup)
     ExeActionRequired(setup_sam_web_client_if_not_setup)
     SetupOptional(jobsub_client)
-    SetupOptional(poms_client)
     SetupOptional(data_dispatcher)
     SetupOptional(awscli)
     PathPrepend(PATH, ${UPS_PROD_DIR}/bin)


### PR DESCRIPTION
Add code to unsetup then setup ups packages, so we can override packages when -B is set in UPS_OVERRIDE. 
Also clean up explicit references to proxies/ use of X509_USER_PROXY
Also fix IFDH_BASE_URI to be the https: path throughout.
Also remove poms_client stuff from fife_launch, not needed (was done to let NOvA use it, who never did) and adds a dependency.